### PR TITLE
Hashjoin draft

### DIFF
--- a/eggstrain/src/execution/mod.rs
+++ b/eggstrain/src/execution/mod.rs
@@ -1,2 +1,4 @@
 pub mod operators;
 pub mod query_dag;
+pub mod record_buffer;
+pub mod record_table;

--- a/eggstrain/src/execution/operators/filter.rs
+++ b/eggstrain/src/execution/operators/filter.rs
@@ -18,7 +18,10 @@ pub(crate) struct Filter {
 
 /// TODO docs
 impl Filter {
-    pub(crate) fn new(predicate: Arc<dyn PhysicalExpr>, children: Vec<Arc<dyn ExecutionPlan>>) -> Self {
+    pub(crate) fn new(
+        predicate: Arc<dyn PhysicalExpr>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Self {
         Self {
             predicate,
             children,

--- a/eggstrain/src/execution/operators/hash_join.rs
+++ b/eggstrain/src/execution/operators/hash_join.rs
@@ -1,6 +1,9 @@
-use super::{Operator, BinaryOperator};
+use super::{BinaryOperator, Operator};
+use crate::execution::record_table::RecordTable;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
+use datafusion::physical_expr::PhysicalExprRef;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_common::Result;
 use std::sync::Arc;
@@ -9,14 +12,86 @@ use tokio::sync::broadcast::error::RecvError;
 
 /// TODO docs
 pub struct HashJoin {
-    pub _todo: bool,
-    pub children: Vec<Arc<dyn ExecutionPlan>>,
+    _todo: bool,
+    children: Vec<Arc<dyn ExecutionPlan>>,
+    schema: SchemaRef,
+    equate_on: Vec<(PhysicalExprRef, PhysicalExprRef)>,
 }
 
 /// TODO docs
 impl HashJoin {
-    pub fn new() -> Self {
-        Self { _todo: false, children: vec![] }
+    pub(crate) fn new(
+        schema: SchemaRef,
+        equate_on: Vec<(PhysicalExprRef, PhysicalExprRef)>,
+    ) -> Self {
+        Self {
+            _todo: false,
+            children: vec![],
+            schema,
+            equate_on,
+        }
+    }
+
+    /// Given a [`RecordBatch`]`, hashes based on the input physical expressions
+    ///
+    /// TODO docs
+    fn hash_batch(&self, batch: &RecordBatch) -> Vec<usize> {
+        todo!("use self.equate_on to hash each of the tuple keys in the batch")
+    }
+
+    /// Builds the Hash Table from the [`RecordBatch`]es coming from the left child.
+    ///
+    /// TODO docs
+    async fn build_table(&self, mut rx_left: broadcast::Receiver<RecordBatch>) -> RecordTable {
+        // Take in all of the record batches from the left and create a hash table
+        let mut record_table = RecordTable::new(self.schema.clone());
+
+        loop {
+            match rx_left.recv().await {
+                Ok(batch) => {
+                    // TODO gather N batches and use rayon to insert all at once
+                    let hashes = self.hash_batch(&batch);
+                    record_table.insert_batch(batch, hashes);
+                }
+                Err(e) => match e {
+                    RecvError::Closed => break,
+                    RecvError::Lagged(_) => todo!(),
+                },
+            }
+        }
+
+        record_table
+    }
+
+    /// Given a single batch (coming from the right child), probes the hash table and outputs a
+    /// [`RecordBatch`] for every tuple on the right that gets matched with a tuple in the hash table.
+    ///
+    /// Note: This is super inefficient since its possible that we could emit a bunch of
+    /// [`RecordBatch`]es that have just 1 tuple in them. This is a place for easy optimization.
+    async fn probe_table(
+        &self,
+        table: &RecordTable,
+        right_batch: RecordBatch,
+        tx: &broadcast::Sender<RecordBatch>,
+    ) {
+        let hashes = self.hash_batch(&right_batch);
+
+        for (right_row, &hash) in hashes.iter().enumerate() {
+            // Construct a RecordBatch for each tuple that might get joined with tuples in the hash table
+
+            // For each of these hashes, check if it is in the table
+            let Some(records) = table.get_records(hash) else {
+                return;
+            };
+            assert!(!records.is_empty());
+
+            // There are records associated with this hash value, so we need to emit things
+            for &record in records {
+                let (left_batch, left_row) = table.get(record).unwrap();
+
+                todo!("Join tuples together and then send through `tx`");
+            }
+        }
     }
 }
 
@@ -34,16 +109,34 @@ impl BinaryOperator for HashJoin {
     type InRight = RecordBatch;
     type Out = RecordBatch;
 
-    fn into_binary(self) -> Arc<dyn BinaryOperator<InLeft = Self::InLeft, InRight = Self::InRight, Out = Self::Out>> {
+    fn into_binary(
+        self,
+    ) -> Arc<dyn BinaryOperator<InLeft = Self::InLeft, InRight = Self::InRight, Out = Self::Out>>
+    {
         Arc::new(self)
     }
 
     async fn execute(
         &self,
         rx_left: broadcast::Receiver<Self::InLeft>,
-        rx_right: broadcast::Receiver<Self::InRight>,
+        mut rx_right: broadcast::Receiver<Self::InRight>,
         tx: broadcast::Sender<Self::Out>,
     ) {
-        todo!()
+        // Phase 1: Build Phase
+        // TODO assign to its own tokio task
+        let record_table = self.build_table(rx_left).await;
+
+        // Phase 2: Probe Phase
+        loop {
+            match rx_right.recv().await {
+                Ok(batch) => {
+                    self.probe_table(&record_table, batch, &tx).await;
+                }
+                Err(e) => match e {
+                    RecvError::Closed => break,
+                    RecvError::Lagged(_) => todo!(),
+                },
+            }
+        }
     }
 }

--- a/eggstrain/src/execution/operators/hash_join.rs
+++ b/eggstrain/src/execution/operators/hash_join.rs
@@ -1,0 +1,49 @@
+use super::{Operator, BinaryOperator};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_common::Result;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::RecvError;
+
+/// TODO docs
+pub struct HashJoin {
+    pub _todo: bool,
+    pub children: Vec<Arc<dyn ExecutionPlan>>,
+}
+
+/// TODO docs
+impl HashJoin {
+    pub fn new() -> Self {
+        Self { _todo: false, children: vec![] }
+    }
+}
+
+/// TODO docs
+impl Operator for HashJoin {
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        self.children.clone()
+    }
+}
+
+/// TODO docs
+#[async_trait]
+impl BinaryOperator for HashJoin {
+    type InLeft = RecordBatch;
+    type InRight = RecordBatch;
+    type Out = RecordBatch;
+
+    fn into_binary(self) -> Arc<dyn BinaryOperator<InLeft = Self::InLeft, InRight = Self::InRight, Out = Self::Out>> {
+        Arc::new(self)
+    }
+
+    async fn execute(
+        &self,
+        rx_left: broadcast::Receiver<Self::InLeft>,
+        rx_right: broadcast::Receiver<Self::InRight>,
+        tx: broadcast::Sender<Self::Out>,
+    ) {
+        todo!()
+    }
+}

--- a/eggstrain/src/execution/operators/mod.rs
+++ b/eggstrain/src/execution/operators/mod.rs
@@ -5,6 +5,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 
 pub mod filter;
 pub mod project;
+pub mod hash_join;
 
 /// Defines shared behavior for all operators
 ///

--- a/eggstrain/src/execution/operators/mod.rs
+++ b/eggstrain/src/execution/operators/mod.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use tokio::sync::broadcast::{Receiver, Sender};
 
 pub mod filter;
-pub mod project;
 pub mod hash_join;
+pub mod project;
 
 /// Defines shared behavior for all operators
 ///

--- a/eggstrain/src/execution/query_dag.rs
+++ b/eggstrain/src/execution/query_dag.rs
@@ -121,8 +121,7 @@ fn datafusion_execute(plan: Arc<dyn ExecutionPlan>, tx: broadcast::Sender<Record
                     continue;
                 }
 
-                tx.send(batch)
-                    .expect("Unable to send rb to project node");
+                tx.send(batch).expect("Unable to send rb to project node");
             }
         }
     });

--- a/eggstrain/src/execution/record_buffer.rs
+++ b/eggstrain/src/execution/record_buffer.rs
@@ -1,0 +1,69 @@
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+
+/// Make this an opaque type that can be used later, we may want to make this contiguous and then
+/// use offsets instead.
+#[derive(Clone, Copy)]
+pub struct RecordIndex {
+    index: u32,
+    row: u32, // by default this is just 0
+}
+
+/// TODO docs
+impl RecordIndex {
+    pub fn new(index: u32, row: u32) -> Self {
+        Self { index, row }
+    }
+
+    pub fn update_row(&mut self, row: u32) {
+        self.row = row;
+    }
+}
+
+pub struct RecordBuffer {
+    schema: SchemaRef,       // The schema for all of the record batches
+    inner: Vec<RecordBatch>, // make this contiguous
+}
+
+impl RecordBuffer {
+    pub fn new(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            inner: vec![],
+        }
+    }
+
+    pub fn with_capacity(schema: SchemaRef, capacity: usize) -> Self {
+        Self {
+            schema,
+            inner: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn insert(&mut self, batch: RecordBatch) -> RecordIndex {
+        assert_eq!(
+            self.schema,
+            batch.schema(),
+            "Trying to insert a RecordBatch into a RecordBuffer with the incorrect schema"
+        );
+        assert!(
+            (self.inner.len() as u32) < u32::MAX - 1,
+            "Maximum size for a RecordBuffer is u32::MAX"
+        );
+
+        self.inner.push(batch);
+
+        RecordIndex {
+            index: (self.inner.len() - 1) as u32,
+            row: 0,
+        }
+    }
+
+    /// Retrieve the batch and row number associated with the RecordIndex
+    pub fn get(&self, index: RecordIndex) -> Option<(&RecordBatch, u32)> {
+        if (index.index as usize) >= self.inner.len() {
+            return None;
+        }
+
+        Some((&self.inner[index.index as usize], index.row))
+    }
+}

--- a/eggstrain/src/execution/record_table.rs
+++ b/eggstrain/src/execution/record_table.rs
@@ -1,0 +1,54 @@
+use super::record_buffer::{RecordBuffer, RecordIndex};
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use std::collections::HashMap; // TODO replace with a raw table
+
+pub struct RecordTable {
+    /// Maps a Hash value to a `RecordIndex` into the `RecordBuffer`
+    inner: HashMap<usize, Vec<RecordIndex>>,
+    buffer: RecordBuffer,
+}
+
+impl RecordTable {
+    pub fn new(schema: SchemaRef) -> Self {
+        Self {
+            buffer: RecordBuffer::new(schema),
+            inner: HashMap::new(),
+        }
+    }
+
+    pub fn with_capacity(schema: SchemaRef, map_capacity: usize, buffer_capacity: usize) -> Self {
+        Self {
+            buffer: RecordBuffer::with_capacity(schema, buffer_capacity),
+            inner: HashMap::with_capacity(map_capacity),
+        }
+    }
+
+    pub fn insert_batch(&mut self, batch: RecordBatch, hashes: Vec<usize>) {
+        assert_eq!(
+            batch.num_rows(),
+            hashes.len(),
+            "There should be an equal amount of batch rows and hashed values"
+        );
+
+        // Points to the location of the base of the record batch
+        let base_record_id = self.buffer.insert(batch);
+
+        for (row, &hash) in hashes.iter().enumerate() {
+            // Given the row, we can create a record id for a specific tuple by updating the row
+            // from the base_record_id
+            let mut record_id = base_record_id;
+            record_id.update_row(row as u32);
+
+            // Insert the record into the hashtable bucket
+            self.inner.entry(hash).or_default().push(record_id)
+        }
+    }
+
+    pub fn get_records(&self, hash: usize) -> Option<&Vec<RecordIndex>> {
+        self.inner.get(&hash)
+    }
+
+    pub fn get(&self, index: RecordIndex) -> Option<(&RecordBatch, u32)> {
+        self.buffer.get(index)
+    }
+}


### PR DESCRIPTION
Note that this is not done yet.

The main two things that need to be implemented are:
- Hashing tuples based on their join keys
- Joining two tuples that have the same join keys (in the context of `RecordBatch`)

For now, I'm just going to take the join keys and hash those and use those as the inner hashmap keys, this is the simpler solution for now.

The helper data structures are also probably abstracted enough so that we can easily replace them with better versions in the futures (better as in more performant + we can add a buffer pool onto them)
